### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Camera Bits, Inc./PhotoMechanic5.pkg.recipe
+++ b/Camera Bits, Inc./PhotoMechanic5.pkg.recipe
@@ -1,28 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Photo Mechanic 5 and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.kevinmcox.pkg.PhotoMechanic5</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of Photo Mechanic 5 and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.kevinmcox.pkg.PhotoMechanic5</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.camerabits.PhotoMechanic</string>
-			<key>NAME</key>
-			<string>Photo Mechanic 5</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.kevinmcox.download.PhotoMechanic5</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>Photo Mechanic 5</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.kevinmcox.download.PhotoMechanic5</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Camera Bits, Inc./PhotoMechanic6.pkg.recipe
+++ b/Camera Bits, Inc./PhotoMechanic6.pkg.recipe
@@ -1,28 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Photo Mechanic 6 and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.kevinmcox.pkg.PhotoMechanic6</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of Photo Mechanic 6 and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.kevinmcox.pkg.PhotoMechanic6</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.camerabits.PhotoMechanic</string>
-			<key>NAME</key>
-			<string>Photo Mechanic 6</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.kevinmcox.download.PhotoMechanic6</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>Photo Mechanic 6</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.kevinmcox.download.PhotoMechanic6</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Camera Bits, Inc./PhotoMechanicPlus.pkg.recipe
+++ b/Camera Bits, Inc./PhotoMechanicPlus.pkg.recipe
@@ -1,28 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Photo Mechanic Plus and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.kevinmcox.pkg.PhotoMechanicPlus</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of Photo Mechanic Plus and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.kevinmcox.pkg.PhotoMechanicPlus</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.camerabits.PhotoMechanic</string>
-			<key>NAME</key>
-			<string>Photo Mechanic Plus</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.kevinmcox.download.PhotoMechanicPlus</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>Photo Mechanic Plus</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.kevinmcox.download.PhotoMechanicPlus</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Micromat, Inc./MachineProfile.pkg.recipe
+++ b/Micromat, Inc./MachineProfile.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.kevinmcox.pkg.MachineProfile</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.micromat.machineprofile</string>
 		<key>NAME</key>
 		<string>MachineProfile</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ Camera Bits, Inc./PhotoMechanic5.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/kevinmcox-recipes/Camera\ Bits,\ Inc./PhotoMechanic5.pkg.recipe
Processing repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanic5.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?<=\\(build\\s)(.*?)(?=\\))',
           'result_output_var_name': 'build',
           'url': 'https://www.camerabits.com/cgi-bin/download_pm.cgi?plat=mac'}}
URLTextSearcher: Found matching text (build): 19749
{'Output': {'build': '19749'}}
URLDownloader
{'Input': {'filename': 'PhotoMechanic5.dmg',
           'url': 'https://www.camerabits.com/download/PhotoMechanic5R19749.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg/Photo '
                         'Mechanic 5.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.camerabits.PhotoMechanic" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "628DA53678")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.dyWVlf/Photo Mechanic 5.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.dyWVlf/Photo Mechanic 5.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.dyWVlf/Photo Mechanic 5.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg/Photo '
                               'Mechanic 5.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg
Versioner: Found version 5.0, build 19749 (20d085a) in file /private/tmp/dmg.X2ZBBX/Photo Mechanic 5.app/Contents/Info.plist
{'Output': {'version': '5.0, build 19749 (20d085a)'}}
AppPkgCreator
{'Input': {'version': '5.0, build 19749 (20d085a)'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/downloads/PhotoMechanic5.dmg
AppPkgCreator: Using path '/private/tmp/dmg.gb8n2W/Photo Mechanic 5.app' matched from globbed '/private/tmp/dmg.gb8n2W/*.app'.
AppPkgCreator: BundleID: com.camerabits.PhotoMechanic
AppPkgCreator: Copied /private/tmp/dmg.gb8n2W/Photo Mechanic 5.app to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/payload/Applications/Photo Mechanic 5.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic5/receipts/PhotoMechanic5.pkg-receipt-20210213-234818.plist

The following recipes failed:
    repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanic5.pkg.recipe
        Error in com.github.kevinmcox.pkg.PhotoMechanic5: Processor: AppPkgCreator: Error: Invalid package name

Nothing downloaded, packaged or imported.
```

## ❌ Camera Bits, Inc./PhotoMechanic6.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/kevinmcox-recipes/Camera\ Bits,\ Inc./PhotoMechanic6.pkg.recipe
Processing repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanic6.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?<=\\(build\\s)(.*?)(?=\\))',
           'result_output_var_name': 'build',
           'url': 'https://www.camerabits.com/cgi-bin/download_pm.cgi?plat=mac&version=PRO'}}
URLTextSearcher: Found matching text (build): 5560
{'Output': {'build': '5560'}}
URLDownloader
{'Input': {'filename': 'PhotoMechanic6.dmg',
           'url': 'https://www.camerabits.com/download/PhotoMechanic6R5560.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg/Photo '
                         'Mechanic 6.app',
           'requirement': 'identifier "com.camerabits.PhotoMechanic" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"628DA53678"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Y46GWX/Photo Mechanic 6.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Y46GWX/Photo Mechanic 6.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Y46GWX/Photo Mechanic 6.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg/Photo '
                               'Mechanic 6.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg
Versioner: Found version 6.0, build 5560 (6e1b8a6) in file /private/tmp/dmg.RA6y3O/Photo Mechanic 6.app/Contents/Info.plist
{'Output': {'version': '6.0, build 5560 (6e1b8a6)'}}
AppPkgCreator
{'Input': {'version': '6.0, build 5560 (6e1b8a6)'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/downloads/PhotoMechanic6.dmg
AppPkgCreator: Using path '/private/tmp/dmg.1beMTm/Photo Mechanic 6.app' matched from globbed '/private/tmp/dmg.1beMTm/*.app'.
AppPkgCreator: BundleID: com.camerabits.PhotoMechanic
AppPkgCreator: Copied /private/tmp/dmg.1beMTm/Photo Mechanic 6.app to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/payload/Applications/Photo Mechanic 6.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanic6/receipts/PhotoMechanic6.pkg-receipt-20210213-234847.plist

The following recipes failed:
    repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanic6.pkg.recipe
        Error in com.github.kevinmcox.pkg.PhotoMechanic6: Processor: AppPkgCreator: Error: Invalid package name

Nothing downloaded, packaged or imported.
```

## ❌ Camera Bits, Inc./PhotoMechanicPlus.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/kevinmcox-recipes/Camera\ Bits,\ Inc./PhotoMechanicPlus.pkg.recipe
Processing repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanicPlus.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?<=\\(build\\s)(.*?)(?=\\))',
           'result_output_var_name': 'build',
           'url': 'https://www.camerabits.com/cgi-bin/download_pm.cgi?plat=mac&version=PLUS'}}
URLTextSearcher: Found matching text (build): 5560
{'Output': {'build': '5560'}}
URLDownloader
{'Input': {'filename': 'PhotoMechanicPlus.dmg',
           'url': 'https://www.camerabits.com/download/PhotoMechanicPlusR5560.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg/Photo '
                         'Mechanic Plus.app',
           'requirement': 'identifier "com.camerabits.PhotoMechanic" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"628DA53678"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.JmSmdp/Photo Mechanic Plus.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.JmSmdp/Photo Mechanic Plus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.JmSmdp/Photo Mechanic Plus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg/Photo '
                               'Mechanic Plus.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg
Versioner: Found version 6.0, build 5560 (6e1b8a6) in file /private/tmp/dmg.b2C9Ig/Photo Mechanic Plus.app/Contents/Info.plist
{'Output': {'version': '6.0, build 5560 (6e1b8a6)'}}
AppPkgCreator
{'Input': {'version': '6.0, build 5560 (6e1b8a6)'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/downloads/PhotoMechanicPlus.dmg
AppPkgCreator: Using path '/private/tmp/dmg.pAfUow/Photo Mechanic Plus.app' matched from globbed '/private/tmp/dmg.pAfUow/*.app'.
AppPkgCreator: BundleID: com.camerabits.PhotoMechanic
AppPkgCreator: Copied /private/tmp/dmg.pAfUow/Photo Mechanic Plus.app to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/payload/Applications/Photo Mechanic Plus.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.PhotoMechanicPlus/receipts/PhotoMechanicPlus.pkg-receipt-20210213-234916.plist

The following recipes failed:
    repos/kevinmcox-recipes/Camera Bits, Inc./PhotoMechanicPlus.pkg.recipe
        Error in com.github.kevinmcox.pkg.PhotoMechanicPlus: Processor: AppPkgCreator: Error: Invalid package name

Nothing downloaded, packaged or imported.
```

## ✅ Micromat, Inc./MachineProfile.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/kevinmcox-recipes/Micromat,\ Inc./MachineProfile.pkg.recipe
Processing repos/kevinmcox-recipes/Micromat, Inc./MachineProfile.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://micromat.com/updates/machineprofile/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1211
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.4.3
SparkleUpdateInfoProvider: Found URL https://s3.amazonaws.com/sw.update.machineprofile/MachineProfile_143_1211.zip
{'Output': {'url': 'https://s3.amazonaws.com/sw.update.machineprofile/MachineProfile_143_1211.zip',
            'version': '1.4.3'}}
URLDownloader
{'Input': {'filename': 'MachineProfile-1.4.3.zip',
           'url': 'https://s3.amazonaws.com/sw.update.machineprofile/MachineProfile_143_1211.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/downloads/MachineProfile-1.4.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/downloads/MachineProfile-1.4.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/downloads/MachineProfile-1.4.3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename MachineProfile-1.4.3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/downloads/MachineProfile-1.4.3.zip to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.micromat.machineprofile" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = PF6S3C5776)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app',
           'version': '1.4.3'}}
AppPkgCreator: BundleID: com.micromat.machineprofile
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile/MachineProfile.app to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/payload/Applications/MachineProfile.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.micromat.machineprofile',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile-1.4.3.pkg',
                                                        'version': '1.4.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.4.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/receipts/MachineProfile.pkg-receipt-20210213-234921.plist

The following packages were built:
    Identifier                   Version  Pkg Path                                                                                               
    ----------                   -------  --------                                                                                               
    com.micromat.machineprofile  1.4.3    ~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.MachineProfile/MachineProfile-1.4.3.pkg  
```

