### PR TITLE
Update DFUBlaster.munki.recipe

### DIFF
--- a/Twocanoes Software/DFUBlaster.munki.recipe
+++ b/Twocanoes Software/DFUBlaster.munki.recipe
@@ -77,6 +77,8 @@
 					<true/>
 					<key>faux_root</key>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<key>version_comparison_key</key>
+					<string>CFBundleVersion</string>
 					<key>installs_item_paths</key>
 					<array>
 						<string>/Applications/DFU Blaster Pro.app</string>
@@ -92,6 +94,8 @@
 			<dict>
 				<key>input_plist_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Applications/DFU Blaster Pro.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/Twocanoes Software/DFUBlaster.munki.recipe
+++ b/Twocanoes Software/DFUBlaster.munki.recipe
@@ -88,6 +88,27 @@
 				<string>MunkiPkginfoMerger</string>
 			</dict>
 			<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications/DFU Blaster Pro.app/Contents/Info.plist</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+			<dict>
 				<key>Processor</key>
 				<string>MunkiImporter</string>
 				<key>Arguments</key>

--- a/Twocanoes Software/DFUBlaster.munki.recipe
+++ b/Twocanoes Software/DFUBlaster.munki.recipe
@@ -77,41 +77,18 @@
 					<true/>
 					<key>faux_root</key>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
-					<key>version_comparison_key</key>
-					<string>CFBundleVersion</string>
 					<key>installs_item_paths</key>
 					<array>
 						<string>/Applications/DFU Blaster Pro.app</string>
 					</array>
+					<key>version_comparison_key</key>
+					<string>CFBundleVersion</string>
 				</dict>
 			</dict>
 			<dict>
 				<key>Processor</key>
 				<string>MunkiPkginfoMerger</string>
 			</dict>
-			<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Applications/DFU Blaster Pro.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
 			<dict>
 				<key>Processor</key>
 				<string>MunkiImporter</string>


### PR DESCRIPTION
His, @kevinmcox 

In the current recipe the `version` variable doesn't match the `version_comparison_key` 

This PR sets the `version` variable to match the version comparison key of `CFBundleShortVersionString`

Output from a successful -v run 
```
autopkg run -v DFUBlaster.munki.recipe
Looking for com.github.kevinmcox.download.DFUBlaster...
Did not find com.github.kevinmcox.download.DFUBlaster in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.kevinmcox.download.DFUBlaster...
Found com.github.kevinmcox.download.DFUBlaster in recipe map
**load_recipe time: 0.0070715420006308705
Processing DFUBlaster.munki.recipe...
WARNING: DFUBlaster.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): /twocanoes/dfu-blaster-public/downloads/PreBeta-DFU_Blaster_Pro_Build-3115_Version-3.2.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 15 Nov 2024 03:29:17 GMT
URLDownloader: Storing new ETag header: "f96b904efba9e42f834f78bf8a3ee971-2"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/downloads/DFUBlaster.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/downloads/DFUBlaster.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DFU Blaster Pro.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-11-15 03:28:04 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            BC 8A 6D 46 65 21 2B 54 4D 3C 19 7D 05 00 F7 20 41 AB 5B C6 47 A4 
CodeSignatureVerifier:            53 26 60 1A 3A 75 9C B6 DC 60
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/downloads/DFUBlaster.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.xKigwl/DFU Blaster Pro.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/unpack/DFU_Blaster_Pro.pkg/payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/payload/
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/DFU Blaster Pro.app
MunkiInstallsItemsCreator: Derived minimum os version as: 14.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.twocanoes.DFU-Blaster-Pro', 'CFBundleName': 'DFU Blaster Pro', 'CFBundleShortVersionString': '3.2', 'CFBundleVersion': '3115', 'minosversion': '14.0', 'path': '/Applications/DFU Blaster Pro.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '14.0'} into pkginfo
Versioner
Versioner: Found version 3.2 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/payload/Applications/DFU Blaster Pro.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '3.2'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/utilities/DFUBlaster/DFUBlaster-3.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/utilities/DFUBlaster/DFUBlaster-3.2.dmg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/payload/
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/unpack
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/receipts/DFUBlaster.munki-receipt-20241125-150736.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.kevinmcox.munki.DFUBlaster/downloads/DFUBlaster.dmg  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----        -------  --------  ------------                               -------------                            --------------  
    DFUBlaster  3.2      testing   utilities/DFUBlaster/DFUBlaster-3.2.plist  utilities/DFUBlaster/DFUBlaster-3.2.dmg
```