### PR TITLE
Update default major versions for Teleport recipes

### DIFF
--- a/Gravitational/TeleportConnect.download.recipe
+++ b/Gravitational/TeleportConnect.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>17</string>
 		<key>NAME</key>
 		<string>TeleportConnect</string>
 	</dict>

--- a/Gravitational/TeleportConnect.munki.recipe
+++ b/Gravitational/TeleportConnect.munki.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>17</string>
 		<key>NAME</key>
 		<string>TeleportConnect</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Gravitational/teleport.download.recipe
+++ b/Gravitational/teleport.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>17</string>
 		<key>NAME</key>
 		<string>Teleport</string>
 	</dict>

--- a/Gravitational/teleport.munki.recipe
+++ b/Gravitational/teleport.munki.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>17</string>
 		<key>NAME</key>
 		<string>Teleport</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Gravitational/tsh.download.recipe
+++ b/Gravitational/tsh.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>16</string>
 		<key>NAME</key>
 		<string>Teleport-tsh</string>
 	</dict>

--- a/Gravitational/tsh.download.recipe
+++ b/Gravitational/tsh.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest release, of the specified major version, of the Teleport tsh client.</string>
+	<string>Downloads the latest release, of the specified major version, of the Teleport tsh client.
+	NOTE: 16.x is the last version of a standalone TSH app. Switch to Teleport for version 17.</string>
 	<key>Identifier</key>
 	<string>com.github.kevinmcox.download.Teleport.tsh</string>
 	<key>Input</key>

--- a/Gravitational/tsh.munki.recipe
+++ b/Gravitational/tsh.munki.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>14</string>
+		<string>16</string>
 		<key>NAME</key>
 		<string>Teleport-tsh</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Gravitational/tsh.munki.recipe
+++ b/Gravitational/tsh.munki.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest release, of the specified major version, of the Teleport tsh client and imports into Munki.</string>
+	<string>Downloads the latest release, of the specified major version, of the Teleport tsh client and imports into Munki.
+	NOTE: 16.x is the last version of a standalone TSH app. Switch to Teleport for version 17.</string>
 	<key>Identifier</key>
 	<string>com.github.kevinmcox.munki.Teleport.tsh</string>
 	<key>Input</key>


### PR DESCRIPTION
This PR updates the major version used to download Teleport products to the current latest of each. (I wasn't able to find a version 17 package for `tsh`.)
