### PR TITLE
Signing cert update for Contour

### DIFF
--- a/Henry Stamerjohann/Contour.download.recipe.yaml
+++ b/Henry Stamerjohann/Contour.download.recipe.yaml
@@ -18,7 +18,7 @@ Process:
   - Processor: CodeSignatureVerifier
     Arguments:
       expected_authority_names:
-        - 'Developer ID Installer: Declarative IT GmbH (D6G4X4D7C9)'
+        - 'Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)'
         - Developer ID Certification Authority
         - Apple Root CA
       input_path: "%pathname%"


### PR DESCRIPTION
per https://github.com/macadmins/contour/releases/tag/v0.1.9

release 0.2.0 to be signed with mac admins cert