### PR TITLE
Use expected_authority_names in ClaudeDesktop

### DIFF
--- a/Anthropic/ClaudeDesktop.pkg.recipe.yaml
+++ b/Anthropic/ClaudeDesktop.pkg.recipe.yaml
@@ -21,7 +21,7 @@ Process:
   - Processor: CodeSignatureVerifier
     Arguments:
       input_path: "%pathname%"
-      requirement:
+      expected_authority_names:
         - "Developer ID Installer: Anthropic PBC (Q6L2SF6YDW)"
         - "Developer ID Certification Authority"
         - "Apple Root CA"


### PR DESCRIPTION
`ClaudeDesktop.pkg.recipe.yaml` passed a list of certificate authority names to the `CodeSignatureVerifier` `requirement` argument. `requirement` takes a single codesign requirement string and is not consulted when verifying an installer package, so the authority chain was never checked. Moving the list to `expected_authority_names` validates the full chain (`Developer ID Installer: Anthropic PBC (Q6L2SF6YDW)` → `Developer ID Certification Authority` → `Apple Root CA`).

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv com.github.kevinmcox.pkg.ClaudeDesktop`

```diff
--- before
+++ after
@@ -1,8 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.ClaudeDesktop/downloads/ClaudeDesktop.pkg',
-           'requirement': ['Developer ID Installer: Anthropic PBC (Q6L2SF6YDW)',
-                           'Developer ID Certification Authority',
-                           'Apple Root CA']}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: Anthropic PBC '
+                                        '(Q6L2SF6YDW)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.kevinmcox.pkg.ClaudeDesktop/downloads/ClaudeDesktop.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Verifying installer package signature...
 CodeSignatureVerifier: Package "ClaudeDesktop.pkg":
@@ -29,4 +30,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```
