### PR TITLE
Add GitHubMonorepoReleasesInfoProvider shared processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,9 @@ This recipe requires a pre-downloaded package, and a version number, to be passe
 
 ### Yuji Tachikawa (yujitach)
 * [MenuMeters](https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/)
+
+## Shared Processors
+
+This repo also includes shared processors in [`SharedProcessors/`](SharedProcessors/) that other recipes (including those in other repos) can use:
+
+* [GitHubMonorepoReleasesInfoProvider](SharedProcessors/README.md) — like the core `GitHubReleasesInfoProvider`, but targets a single component in a monorepo that uses per-component tag prefixes (e.g. `cli/v1.4.2`), and derives a clean version from the prefixed tag.

--- a/SharedProcessors/GitHubMonorepoReleasesInfoProvider.py
+++ b/SharedProcessors/GitHubMonorepoReleasesInfoProvider.py
@@ -1,0 +1,104 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2026 Kevin M. Cox
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for GitHubMonorepoReleasesInfoProvider class"""
+
+import re
+
+from autopkglib import ProcessorError
+from autopkglib.GitHubReleasesInfoProvider import GitHubReleasesInfoProvider
+
+__all__ = ["GitHubMonorepoReleasesInfoProvider"]
+
+
+class GitHubMonorepoReleasesInfoProvider(GitHubReleasesInfoProvider):
+    """Like GitHubReleasesInfoProvider, but adds a 'tag_regex' input for
+    monorepos that publish several components from one repo using
+    per-component tag prefixes (e.g. 'cli/v1.4.2' alongside 'server/v2.1.0').
+
+    The stock processor selects the newest release whose assets match
+    'asset_regex', and derives 'version' by naively stripping a leading 'v'
+    from the tag. Prefixed tags break the version: 'cli/v1.4.2' does not start
+    with 'v', so 'version' comes out as the whole prefixed tag.
+
+    This subclass:
+      * restricts release selection to releases whose 'tag_name' matches
+        'tag_regex', so sibling components are skipped even if their assets
+        would otherwise satisfy 'asset_regex'; and
+      * if 'tag_regex' contains a capture group, uses the first group as the
+        'version' output instead of the naive leading-'v' strip.
+
+    Everything else - pagination, prerelease handling, sort_by_highest_tag_names,
+    private-repo auth, and all output variables - is inherited unchanged from
+    the parent processor.
+    """
+
+    description = __doc__
+
+    input_variables = dict(GitHubReleasesInfoProvider.input_variables)
+    input_variables["tag_regex"] = {
+        "required": False,
+        "description": (
+            "If set, only releases whose 'tag_name' matches this regex "
+            "(via re.search) are eligible for selection. Use it to target a "
+            "single component in a monorepo, e.g. '^cli/'. "
+            "If the regex contains a capture group, the first group is used "
+            "as the 'version' output variable; e.g. '^cli/v?(.+)$' "
+            "yields '1.4.2' from the tag 'cli/v1.4.2'. Without a "
+            "capture group, version derivation falls back to the parent's "
+            "naive leading-'v' strip."
+        ),
+    }
+
+    output_variables = dict(GitHubReleasesInfoProvider.output_variables)
+
+    def select_asset(self, releases, regex):
+        """Filter candidate releases by 'tag_regex' (if set) before deferring
+        to the parent's asset-selection logic. Filtering here rather than in
+        main() means the parent's pagination loop keeps fetching pages until
+        it finds a tag-matching release that also has a matching asset."""
+        tag_regex = self.env.get("tag_regex")
+        if tag_regex:
+            try:
+                releases = [
+                    rel for rel in releases if re.search(tag_regex, rel["tag_name"])
+                ]
+            except re.error as err:
+                raise ProcessorError(f"Invalid tag_regex: {err}")
+        # The parent raises NoMatchingReleaseError when nothing here is
+        # eligible, which its main() catches to advance to the next page.
+        super().select_asset(releases, regex)
+
+    def main(self):
+        # The parent does all the work: pagination, selection (through our
+        # overridden select_asset), URLs, release notes, and a first pass at
+        # 'version'.
+        super().main()
+
+        # If tag_regex supplied a capture group, prefer it for the version.
+        tag_regex = self.env.get("tag_regex")
+        if tag_regex:
+            match = re.search(tag_regex, self.selected_release["tag_name"])
+            if match and match.groups() and match.group(1):
+                self.env["version"] = match.group(1)
+                self.output(
+                    f"Derived version '{self.env['version']}' from tag "
+                    f"'{self.selected_release['tag_name']}' via tag_regex"
+                )
+
+
+if __name__ == "__main__":
+    PROCESSOR = GitHubMonorepoReleasesInfoProvider()
+    PROCESSOR.execute_shell()

--- a/SharedProcessors/README.md
+++ b/SharedProcessors/README.md
@@ -1,0 +1,50 @@
+# GitHubMonorepoReleasesInfoProvider
+
+A drop-in subclass of AutoPkg's core [`GitHubReleasesInfoProvider`](https://github.com/autopkg/autopkg/wiki/Processor-GitHubReleasesInfoProvider) for **monorepos that publish multiple components from a single repository using per-component tag prefixes** — for example `cli/v1.4.2` alongside `server/v2.1.0`.
+
+## The problem it solves
+
+The core processor selects the newest release whose assets match `asset_regex`, then derives the version by naively stripping a leading `v` from the tag. In a monorepo that breaks in two ways:
+
+1. **Wrong release.** The newest release is whichever component was published most recently, not the one you want. `asset_regex` only helps if that component happens to ship a uniquely-named asset.
+2. **Garbage version.** A prefixed tag like `cli/v1.4.2` doesn't start with `v`, so the `version` output becomes the whole string `cli/v1.4.2` instead of `1.4.2`.
+
+This processor adds a single `tag_regex` input that fixes both.
+
+## Input variables
+
+Everything from `GitHubReleasesInfoProvider` is inherited unchanged (`github_repo`, `asset_regex`, `include_prereleases`, `sort_by_highest_tag_names`, `GITHUB_TOKEN_PATH`, pagination, etc.), plus:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `tag_regex` | No | Only releases whose `tag_name` matches this regex (via `re.search`) are eligible for selection. Use it to target one component in a monorepo, e.g. `^cli/`. If the regex contains a capture group, the **first group** is used as the `version` output; e.g. `^cli/v?(.+)$` yields `1.4.2` from the tag `cli/v1.4.2`. Without a capture group, version derivation falls back to the parent's naive leading-`v` strip. |
+
+Release selection still walks releases newest-first (or by highest tag if `sort_by_highest_tag_names` is set), skipping any release whose tag doesn't match `tag_regex`, and paginates until it finds a matching release that also has a matching asset.
+
+## Output variables
+
+Identical to `GitHubReleasesInfoProvider`: `url`, `asset_url`, `version`, `release_notes`, `asset_created_at`. (`version` is the one improved by `tag_regex`.)
+
+## Example
+
+```yaml
+Process:
+  - Processor: com.github.kevinmcox.SharedProcessors/GitHubMonorepoReleasesInfoProvider
+    Arguments:
+      github_repo: "exampleorg/monorepo"
+      tag_regex: '^cli/v?(.+)$'
+      asset_regex: 'mytool_.*_darwin_arm64\.tar\.gz'
+
+  - Processor: URLDownloader
+    Arguments:
+      filename: "mytool.tar.gz"
+
+  - Processor: EndOfCheckPhase
+```
+
+`tag_regex` adapts to whatever scheme the repo uses — `^cli/`, `^cli-v`, `^components/cli@`, etc. The capture group simply needs to wrap the part you want as the version.
+
+## Notes
+
+- **Private repositories.** Downloading a private repo's asset must go through the API `asset_url` (not the `browser_download_url`), with an `Accept: application/octet-stream` header and a token. Point `URLDownloader` at `%asset_url%` and add `request_headers` for `Authorization` and `Accept`.
+- **Pagination.** Monorepos can bury a component's releases hundreds of entries deep; the inherited pagination loop handles this, so an authenticated `GITHUB_TOKEN` is recommended to stay within rate limits.

--- a/SharedProcessors/SharedProcessors.recipe.yaml
+++ b/SharedProcessors/SharedProcessors.recipe.yaml
@@ -1,0 +1,10 @@
+Description: |
+  Stub recipe to locate the shared processors in this directory. Reference a
+  processor by prefixing this identifier to its name, e.g.:
+  com.github.kevinmcox.SharedProcessors/GitHubMonorepoReleasesInfoProvider
+Identifier: com.github.kevinmcox.SharedProcessors
+MinimumVersion: "2.3"
+
+Input: {}
+
+Process: []


### PR DESCRIPTION
A subclass of the core GitHubReleasesInfoProvider for monorepos that publish multiple components using per-component tag prefixes (e.g. cli/v1.4.2). Adds a tag_regex input that restricts release selection to a single component and derives a clean version from the prefixed tag via an optional capture group.

All other behavior (pagination, prereleases, auth) is inherited unchanged.